### PR TITLE
Update README instructions [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TKTK
 
    - Clone this repo with `git clone https://github.com/takeshape/takeshape-starter-deluxe-sample-project.git`.
    - `cd` into the folder that the cloning created.
-   - Run `mv .env.local-example .env.local` to rename the environment variables file.
+   - Run `cp .env.local-example .env.local` to rename the environment variables file.
    - Run `npm install`.
 
 2. Follow the instructions in `.env.local`.


### PR DESCRIPTION
While going through setup, using `mv` on the `env.local-example` deleted the file from the file tree. Since we don't want it inadvertently removed, I think that  copying the true env file leads to a clearer flow.